### PR TITLE
Add ride crash normalization replacement trains

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -3830,3 +3830,5 @@ STR_6788    :Sensitivity:
 STR_6789    :Analogue stick sensitivity multiplier
 STR_6790    :Deadzone: {COMMA32}%
 STR_6791    :Sensitivity: {COMMA32}%
+STR_6792    :Allow incomplete rides
+STR_6793    :Normalize ride crashes

--- a/src/openrct2-ui/windows/Cheats.cpp
+++ b/src/openrct2-ui/windows/Cheats.cpp
@@ -183,6 +183,8 @@ enum WindowCheatsWidgetIdx
     WIDX_SHOW_VEHICLES_FROM_OTHER_TRACK_TYPES,
     WIDX_DISABLE_TRAIN_LENGTH_LIMITS,
     WIDX_IGNORE_RESEARCH_STATUS,
+    WIDX_ALLOW_INCOMPLETE_RIDES,
+    WIDX_NORMALIZE_RIDE_CRASHES,
 
     WIDX_WEATHER_GROUP = WIDX_TAB_CONTENT,
     WIDX_WEATHER,
@@ -331,11 +333,13 @@ static constexpr auto window_cheats_rides_widgets = makeWidgets(
     makeWidget({ 11, 252}, kCheatCheckSize,  WidgetType::checkbox, WindowColour::secondary, STR_CHEAT_DISABLE_BREAKDOWNS,                   STR_CHEAT_DISABLE_BREAKDOWNS_TIP               ), // Disable all breakdowns
     makeWidget({ 11, 269}, kCheatCheckSize,  WidgetType::checkbox, WindowColour::secondary, STR_CHEAT_DISABLE_RIDE_VALUE_AGING,             STR_CHEAT_DISABLE_RIDE_VALUE_AGING_TIP         ), // Disable ride ageing
 
-    makeWidget({  5, 292}, {238, 86},        WidgetType::groupbox, WindowColour::secondary, STR_CHEAT_GROUP_AVAILABILITY                                                                   ), // Availability group
+    makeWidget({  5, 292}, {238, 120},        WidgetType::groupbox, WindowColour::secondary, STR_CHEAT_GROUP_AVAILABILITY                                                                   ), // Availability group
     makeWidget({ 11, 308}, kCheatCheckSize,  WidgetType::checkbox, WindowColour::secondary, STR_CHEAT_ALLOW_ARBITRARY_RIDE_TYPE_CHANGES,    STR_CHEAT_ALLOW_ARBITRARY_RIDE_TYPE_CHANGES_TIP), // Allow arbitrary ride type changes
     makeWidget({ 11, 325}, kCheatCheckSize,  WidgetType::checkbox, WindowColour::secondary, STR_CHEAT_SHOW_VEHICLES_FROM_OTHER_TRACK_TYPES                                                 ), // Show vehicles from other track types
     makeWidget({ 11, 342}, kCheatCheckSize,  WidgetType::checkbox, WindowColour::secondary, STR_CHEAT_DISABLE_TRAIN_LENGTH_LIMIT,           STR_CHEAT_DISABLE_TRAIN_LENGTH_LIMIT_TIP       ), // Disable train length limits
-    makeWidget({ 11, 359}, kCheatCheckSize,  WidgetType::checkbox, WindowColour::secondary, STR_CHEAT_IGNORE_RESEARCH_STATUS,               STR_CHEAT_IGNORE_RESEARCH_STATUS_TIP           )  // Ignore Research Status
+    makeWidget({ 11, 359}, kCheatCheckSize,  WidgetType::checkbox, WindowColour::secondary, STR_CHEAT_IGNORE_RESEARCH_STATUS,               STR_CHEAT_IGNORE_RESEARCH_STATUS_TIP           ), // Ignore Research Status
+    makeWidget({ 11, 376}, kCheatCheckSize,  WidgetType::checkbox, WindowColour::secondary, STR_ALLOW_INCOMPLETE_RIDES                    ), // Allow incomplete rides
+    makeWidget({ 11, 393}, kCheatCheckSize,  WidgetType::checkbox, WindowColour::secondary, STR_NORMALIZE_RIDE_CRASHES                     )
 );
 
 static constexpr auto window_cheats_weather_widgets = makeWidgets(
@@ -564,6 +568,8 @@ static StringId window_cheats_page_titles[] = {
                     SetCheckboxValue(WIDX_ENABLE_ALL_DRAWABLE_TRACK_PIECES, gameState.cheats.enableAllDrawableTrackPieces);
                     SetCheckboxValue(WIDX_ALLOW_TRACK_PLACE_INVALID_HEIGHTS, gameState.cheats.allowTrackPlaceInvalidHeights);
                     SetCheckboxValue(WIDX_MAKE_DESTRUCTIBLE, gameState.cheats.makeAllDestructible);
+                    SetCheckboxValue(WIDX_ALLOW_INCOMPLETE_RIDES, gameState.cheats.allowIncompleteRides);
+                    SetCheckboxValue(WIDX_NORMALIZE_RIDE_CRASHES, gameState.cheats.normalizeRideCrashes);
                     break;
                 case WINDOW_CHEATS_PAGE_STAFF:
                     SetCheckboxValue(WIDX_DISABLE_PLANT_AGING, gameState.cheats.disablePlantAging);
@@ -1337,6 +1343,13 @@ static StringId window_cheats_page_titles[] = {
                         ContextShowError(STR_WARNING_IN_CAPS, STR_THIS_FEATURE_IS_CURRENTLY_UNSTABLE, {});
                     }
                     CheatsSet(CheatType::AllowTrackPlaceInvalidHeights, !gameState.cheats.allowTrackPlaceInvalidHeights);
+                    break;
+                case WIDX_ALLOW_INCOMPLETE_RIDES:
+                    CheatsSet(CheatType::AllowIncompleteRides, !gameState.cheats.allowIncompleteRides);
+                    break;
+                case WIDX_NORMALIZE_RIDE_CRASHES:
+                    CheatsSet(CheatType::NormalizeRideCrashes, !gameState.cheats.normalizeRideCrashes);
+                    break;
                 }
                 break;
             }

--- a/src/openrct2/Cheats.cpp
+++ b/src/openrct2/Cheats.cpp
@@ -55,6 +55,8 @@ void CheatsReset()
     gameState.cheats.allowRegularPathAsQueue = false;
     gameState.cheats.allowSpecialColourSchemes = false;
     gameState.cheats.makeAllDestructible = false;
+    gameState.cheats.allowIncompleteRides = false;
+    gameState.cheats.normalizeRideCrashes = false;
     gameState.cheats.selectedStaffSpeed = StaffSpeedCheat::None;
     gameState.cheats.forcedParkRating = kForcedParkRatingDisabled;
 }
@@ -113,6 +115,8 @@ void CheatsSerialise(DataSerialiser& ds)
         CheatEntrySerialise(ds, CheatType::AllowRegularPathAsQueue, gameState.cheats.allowRegularPathAsQueue, count);
         CheatEntrySerialise(ds, CheatType::AllowSpecialColourSchemes, gameState.cheats.allowSpecialColourSchemes, count);
         CheatEntrySerialise(ds, CheatType::MakeDestructible, gameState.cheats.makeAllDestructible, count);
+        CheatEntrySerialise(ds, CheatType::AllowIncompleteRides, gameState.cheats.allowIncompleteRides, count);
+        CheatEntrySerialise(ds, CheatType::NormalizeRideCrashes, gameState.cheats.normalizeRideCrashes, count);
         CheatEntrySerialise(ds, CheatType::SetStaffSpeed, gameState.cheats.selectedStaffSpeed, count);
         CheatEntrySerialise(ds, CheatType::IgnorePrice, gameState.cheats.ignorePrice, count);
         CheatEntrySerialise(ds, CheatType::SetForcedParkRating, gameState.cheats.forcedParkRating, count);
@@ -219,6 +223,12 @@ void CheatsSerialise(DataSerialiser& ds)
                     break;
                 case CheatType::MakeDestructible:
                     ds << gameState.cheats.makeAllDestructible;
+                    break;
+                case CheatType::AllowIncompleteRides:
+                    ds << gameState.cheats.allowIncompleteRides;
+                    break;
+                case CheatType::NormalizeRideCrashes:
+                    ds << gameState.cheats.normalizeRideCrashes;
                     break;
                 case CheatType::SetStaffSpeed:
                     ds << gameState.cheats.selectedStaffSpeed;
@@ -335,6 +345,10 @@ const char* CheatsGetName(CheatType cheatType)
             return LanguageGetString(STR_CHEAT_ALLOW_PATH_AS_QUEUE);
         case CheatType::AllowSpecialColourSchemes:
             return LanguageGetString(STR_CHEAT_ALLOW_SPECIAL_COLOUR_SCHEMES);
+        case CheatType::AllowIncompleteRides:
+            return "Allow incomplete rides";
+        case CheatType::NormalizeRideCrashes:
+            return "Normalize ride crashes";
         case CheatType::RemoveParkFences:
             return LanguageGetString(STR_CHEAT_REMOVE_PARK_FENCES);
         default:

--- a/src/openrct2/Cheats.h
+++ b/src/openrct2/Cheats.h
@@ -46,6 +46,8 @@ struct CheatsState
     bool allowRegularPathAsQueue;
     bool allowSpecialColourSchemes;
     bool makeAllDestructible;
+    bool allowIncompleteRides;
+    bool normalizeRideCrashes;
     StaffSpeedCheat selectedStaffSpeed;
     int32_t forcedParkRating;
 };
@@ -104,6 +106,8 @@ enum class CheatType : int32_t
     NoCapOnQueueLengthDummy, // Removed; this dummy exists only for deserialisation parks that had it saved
     AllowRegularPathAsQueue,
     AllowSpecialColourSchemes,
+    AllowIncompleteRides,
+    NormalizeRideCrashes,
     RemoveParkFences,
     IgnorePrice,
     Count,

--- a/src/openrct2/actions/CheatSetAction.cpp
+++ b/src/openrct2/actions/CheatSetAction.cpp
@@ -270,6 +270,12 @@ GameActions::Result CheatSetAction::Execute() const
         case CheatType::AllowSpecialColourSchemes:
             gameState.cheats.allowSpecialColourSchemes = static_cast<bool>(_param1);
             break;
+        case CheatType::AllowIncompleteRides:
+            gameState.cheats.allowIncompleteRides = _param1 != 0;
+            break;
+        case CheatType::NormalizeRideCrashes:
+            gameState.cheats.normalizeRideCrashes = _param1 != 0;
+            break;
         case CheatType::RemoveParkFences:
             RemoveParkFences();
             break;
@@ -349,6 +355,10 @@ ParametersRange CheatSetAction::GetParameterRange(CheatType cheatType) const
         case CheatType::AllowSpecialColourSchemes:
             [[fallthrough]];
         case CheatType::AllowTrackPlaceInvalidHeights:
+            [[fallthrough]];
+        case CheatType::AllowIncompleteRides:
+            [[fallthrough]];
+        case CheatType::NormalizeRideCrashes:
             [[fallthrough]];
         case CheatType::OpenClosePark:
             return { { 0, 1 }, { 0, 0 } };

--- a/src/openrct2/localisation/StringIds.h
+++ b/src/openrct2/localisation/StringIds.h
@@ -1736,6 +1736,8 @@ enum : StringId
     STR_GAMEPAD_SENSITIVITY_TIP = 6789,
     STR_GAMEPAD_DEADZONE_TOOLTIP_FORMAT = 6790,
     STR_GAMEPAD_SENSITIVITY_TOOLTIP_FORMAT = 6791,
+    STR_ALLOW_INCOMPLETE_RIDES = 6792,
+    STR_NORMALIZE_RIDE_CRASHES = 6793,
 
     // Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
     /* MAX_STR_COUNT = 32768 */ // MAX_STR_COUNT - upper limit for number of strings, not the current count strings

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -4051,16 +4051,19 @@ ResultWithMessage Ride::test(bool isApplying)
         return message;
     }
 
-    message = changeStatusCheckCompleteCircuit(trackElement);
-    if (!message.Successful)
+    if (!getGameState().cheats.allowIncompleteRides)
     {
-        return message;
-    }
+        message = changeStatusCheckCompleteCircuit(trackElement);
+        if (!message.Successful)
+        {
+            return message;
+        }
 
-    message = changeStatusCheckTrackValidity(trackElement);
-    if (!message.Successful)
-    {
-        return message;
+        message = changeStatusCheckTrackValidity(trackElement);
+        if (!message.Successful)
+        {
+            return message;
+        }
     }
 
     return changeStatusCreateVehicles(isApplying, trackElement);
@@ -4088,16 +4091,19 @@ ResultWithMessage Ride::simulate(bool isApplying)
         return message;
     }
 
-    if (isBlockSectioned() && findTrackGap(trackElement, &problematicTrackElement))
+    if (!getGameState().cheats.allowIncompleteRides)
     {
-        RideScrollToTrackError(problematicTrackElement);
-        return { false, STR_TRACK_IS_NOT_A_COMPLETE_CIRCUIT };
-    }
+        if (isBlockSectioned() && findTrackGap(trackElement, &problematicTrackElement))
+        {
+            RideScrollToTrackError(problematicTrackElement);
+            return { false, STR_TRACK_IS_NOT_A_COMPLETE_CIRCUIT };
+        }
 
-    message = changeStatusCheckTrackValidity(trackElement);
-    if (!message.Successful)
-    {
-        return message;
+        message = changeStatusCheckTrackValidity(trackElement);
+        if (!message.Successful)
+        {
+            return message;
+        }
     }
 
     return changeStatusCreateVehicles(isApplying, trackElement);
@@ -4146,16 +4152,19 @@ ResultWithMessage Ride::open(bool isApplying)
         return message;
     }
 
-    message = changeStatusCheckCompleteCircuit(trackElement);
-    if (!message.Successful)
+    if (!getGameState().cheats.allowIncompleteRides)
     {
-        return message;
-    }
+        message = changeStatusCheckCompleteCircuit(trackElement);
+        if (!message.Successful)
+        {
+            return message;
+        }
 
-    message = changeStatusCheckTrackValidity(trackElement);
-    if (!message.Successful)
-    {
-        return message;
+        message = changeStatusCheckTrackValidity(trackElement);
+        if (!message.Successful)
+        {
+            return message;
+        }
     }
 
     return changeStatusCreateVehicles(isApplying, trackElement);
@@ -5324,6 +5333,55 @@ void Ride::renew()
     // Set build date to current date (so the ride is brand new)
     buildDate = GetDate().GetMonthsElapsed();
     reliability = kRideInitialReliability;
+}
+
+void Ride::spawnReplacementTrain(uint8_t trainIndex)
+{
+    if (numTrains >= maxTrains)
+        return;
+
+    StationIndex stationIndex = RideGetFirstValidStationStart(*this);
+    if (stationIndex.IsNull())
+        return;
+
+    TileElement* tileElement = RideGetStationStartTrackElement(*this, stationIndex);
+    if (tileElement == nullptr)
+        return;
+
+    TrackElement* trackElement = tileElement->AsTrack();
+    CoordsXYZ trainPos = getStation(stationIndex).GetStart();
+    trainPos.z = trackElement->GetBaseZ();
+
+    int32_t remainingDistance = 0;
+    TrainReference train = VehicleCreateTrain(*this, trainPos, trainIndex, &remainingDistance, trackElement);
+    if (train.head == nullptr || train.tail == nullptr)
+        return;
+
+    if (!vehicles[0].IsNull())
+    {
+        Vehicle* firstTrain = GetEntity<Vehicle>(vehicles[0]);
+        if (firstTrain != nullptr)
+        {
+            Vehicle* lastTrainTail = GetEntity<Vehicle>(firstTrain->prev_vehicle_on_ride);
+            if (lastTrainTail != nullptr)
+            {
+                lastTrainTail->next_vehicle_on_ride = train.head->Id;
+                train.head->prev_vehicle_on_ride = lastTrainTail->Id;
+                train.tail->next_vehicle_on_ride = firstTrain->Id;
+                firstTrain->prev_vehicle_on_ride = train.tail->Id;
+            }
+        }
+    }
+    else
+    {
+        vehicles[0] = train.head->Id;
+        train.head->prev_vehicle_on_ride = train.tail->Id;
+        train.tail->next_vehicle_on_ride = train.head->Id;
+    }
+
+    vehicles[trainIndex] = train.head->Id;
+    numTrains = std::min<uint8_t>(numTrains + 1, maxTrains);
+    proposedNumTrains = numTrains;
 }
 
 RideClassification Ride::getClassification() const

--- a/src/openrct2/ride/Ride.h
+++ b/src/openrct2/ride/Ride.h
@@ -354,6 +354,13 @@ public:
     void updateMaxVehicles();
     void updateNumberOfCircuits();
 
+    /**
+     * Spawn a replacement train at the first station start. Used when
+     * normalising crashes so the ride keeps operating with the same
+     * number of trains.
+     */
+    void spawnReplacementTrain(uint8_t trainIndex);
+
     bool hasSpinningTunnel() const;
     bool hasWaterSplash() const;
     bool hasRapids() const;

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -2850,18 +2850,22 @@ void Vehicle::UpdateCollisionSetup()
 
     SetState(Vehicle::Status::Crashed, sub_state);
 
+    std::optional<uint8_t> crashedTrainIndex;
+
+    auto frontVehicle = GetHead();
+    auto trainIndex = ride_get_train_index_from_vehicle(*curRide, frontVehicle->Id);
+    if (!trainIndex.has_value())
+    {
+        return;
+    }
+
+    crashedTrainIndex = static_cast<uint8_t>(trainIndex.value());
+
     if (!(curRide->lifecycleFlags & RIDE_LIFECYCLE_CRASHED))
     {
-        auto frontVehicle = GetHead();
-        auto trainIndex = ride_get_train_index_from_vehicle(*curRide, frontVehicle->Id);
-        if (!trainIndex.has_value())
-        {
-            return;
-        }
-
         curRide->crash(trainIndex.value());
 
-        if (curRide->status != RideStatus::closed)
+        if (!getGameState().cheats.normalizeRideCrashes && curRide->status != RideStatus::closed)
         {
             // We require this to execute right away during the simulation, always ignore network and queue.
             auto gameAction = RideSetStatusAction(curRide->id, RideStatus::closed);
@@ -2869,8 +2873,11 @@ void Vehicle::UpdateCollisionSetup()
         }
     }
 
-    curRide->lifecycleFlags |= RIDE_LIFECYCLE_CRASHED;
-    curRide->windowInvalidateFlags |= RIDE_INVALIDATE_RIDE_MAIN | RIDE_INVALIDATE_RIDE_LIST;
+    if (!getGameState().cheats.normalizeRideCrashes)
+    {
+        curRide->lifecycleFlags |= RIDE_LIFECYCLE_CRASHED;
+        curRide->windowInvalidateFlags |= RIDE_INVALIDATE_RIDE_MAIN | RIDE_INVALIDATE_RIDE_LIST;
+    }
     KillAllPassengersInTrain();
 
     Vehicle* lastVehicle = this;
@@ -2920,7 +2927,13 @@ void Vehicle::UpdateCollisionSetup()
         nextTrain->prev_vehicle_on_ride = prev_vehicle_on_ride;
     }
 
+
     velocity = 0;
+
+    if (crashedTrainIndex.has_value() && getGameState().cheats.normalizeRideCrashes)
+    {
+        curRide->spawnReplacementTrain(*crashedTrainIndex);
+    }
 }
 
 /** rct2: 0x009A3AC4, 0x009A3AC6 */
@@ -3000,6 +3013,8 @@ void Vehicle::UpdateCrashSetup()
         prevTrain->next_vehicle_on_ride = lastVehicle->next_vehicle_on_ride;
         nextTrain->prev_vehicle_on_ride = prev_vehicle_on_ride;
     }
+
+
     velocity = 0;
 }
 
@@ -4588,7 +4603,10 @@ void Vehicle::KillAllPassengersInTrain()
     if (curRide == nullptr)
         return;
 
-    ride_train_crash(*curRide, NumPeepsUntilTrainTail());
+    if (!getGameState().cheats.normalizeRideCrashes)
+    {
+        ride_train_crash(*curRide, NumPeepsUntilTrainTail());
+    }
 
     for (Vehicle* trainCar = GetEntity<Vehicle>(Id); trainCar != nullptr;
          trainCar = GetEntity<Vehicle>(trainCar->next_vehicle_on_train))
@@ -4641,26 +4659,33 @@ void Vehicle::CrashOnLand()
     InvokeVehicleCrashHook(Id, "land");
 #endif
 
+    std::optional<uint8_t> crashedTrainIndex;
+
+    auto frontVehicle = GetHead();
+    auto trainIndex = ride_get_train_index_from_vehicle(*curRide, frontVehicle->Id);
+    if (!trainIndex.has_value())
+    {
+        return;
+    }
+
+    crashedTrainIndex = static_cast<uint8_t>(trainIndex.value());
+
     if (!(curRide->lifecycleFlags & RIDE_LIFECYCLE_CRASHED))
     {
-        auto frontVehicle = GetHead();
-        auto trainIndex = ride_get_train_index_from_vehicle(*curRide, frontVehicle->Id);
-        if (!trainIndex.has_value())
-        {
-            return;
-        }
-
         curRide->crash(trainIndex.value());
 
-        if (curRide->status != RideStatus::closed)
+        if (!getGameState().cheats.normalizeRideCrashes && curRide->status != RideStatus::closed)
         {
             // We require this to execute right away during the simulation, always ignore network and queue.
             auto gameAction = RideSetStatusAction(curRide->id, RideStatus::closed);
             GameActions::ExecuteNested(&gameAction);
         }
     }
-    curRide->lifecycleFlags |= RIDE_LIFECYCLE_CRASHED;
-    curRide->windowInvalidateFlags |= RIDE_INVALIDATE_RIDE_MAIN | RIDE_INVALIDATE_RIDE_LIST;
+    if (!getGameState().cheats.normalizeRideCrashes)
+    {
+        curRide->lifecycleFlags |= RIDE_LIFECYCLE_CRASHED;
+        curRide->windowInvalidateFlags |= RIDE_INVALIDATE_RIDE_MAIN | RIDE_INVALIDATE_RIDE_LIST;
+    }
 
     if (IsHead())
     {
@@ -4690,6 +4715,11 @@ void Vehicle::CrashOnLand()
     MoveTo(curLoc);
 
     crash_z = 0;
+
+    if (crashedTrainIndex.has_value() && getGameState().cheats.normalizeRideCrashes)
+    {
+        curRide->spawnReplacementTrain(*crashedTrainIndex);
+    }
 }
 
 void Vehicle::CrashOnWater()
@@ -4709,26 +4739,33 @@ void Vehicle::CrashOnWater()
     InvokeVehicleCrashHook(Id, "water");
 #endif
 
+    std::optional<uint8_t> crashedTrainIndex;
+
+    auto frontVehicle = GetHead();
+    auto trainIndex = ride_get_train_index_from_vehicle(*curRide, frontVehicle->Id);
+    if (!trainIndex.has_value())
+    {
+        return;
+    }
+
+    crashedTrainIndex = static_cast<uint8_t>(trainIndex.value());
+
     if (!(curRide->lifecycleFlags & RIDE_LIFECYCLE_CRASHED))
     {
-        auto frontVehicle = GetHead();
-        auto trainIndex = ride_get_train_index_from_vehicle(*curRide, frontVehicle->Id);
-        if (!trainIndex.has_value())
-        {
-            return;
-        }
-
         curRide->crash(trainIndex.value());
 
-        if (curRide->status != RideStatus::closed)
+        if (!getGameState().cheats.normalizeRideCrashes && curRide->status != RideStatus::closed)
         {
             // We require this to execute right away during the simulation, always ignore network and queue.
             auto gameAction = RideSetStatusAction(curRide->id, RideStatus::closed);
             GameActions::ExecuteNested(&gameAction);
         }
     }
-    curRide->lifecycleFlags |= RIDE_LIFECYCLE_CRASHED;
-    curRide->windowInvalidateFlags |= RIDE_INVALIDATE_RIDE_MAIN | RIDE_INVALIDATE_RIDE_LIST;
+    if (!getGameState().cheats.normalizeRideCrashes)
+    {
+        curRide->lifecycleFlags |= RIDE_LIFECYCLE_CRASHED;
+        curRide->windowInvalidateFlags |= RIDE_INVALIDATE_RIDE_MAIN | RIDE_INVALIDATE_RIDE_LIST;
+    }
 
     if (IsHead())
     {
@@ -4759,6 +4796,11 @@ void Vehicle::CrashOnWater()
     MoveTo(curLoc);
 
     crash_z = -1;
+
+    if (crashedTrainIndex.has_value() && getGameState().cheats.normalizeRideCrashes)
+    {
+        curRide->spawnReplacementTrain(*crashedTrainIndex);
+    }
 }
 
 /**


### PR DESCRIPTION
## Summary
- add function `spawnReplacementTrain` to ride
- use new cheat to spawn train when normalizing crashes
- include optional header for vehicles
- spawn replacement car when each train crashes (fix cheat logic)

## Testing
- No tests run due to instructions

------
https://chatgpt.com/codex/tasks/task_e_6872d01c038883328ca9e8b93692ee1e