### PR TITLE
Fix replacement train spawn with cheat enabled

### DIFF
--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -5337,16 +5337,26 @@ void Ride::renew()
 
 void Ride::spawnReplacementTrain(uint8_t trainIndex)
 {
+    LOG_VERBOSE("Ride %u: attempt to spawn replacement train %u", id.ToUnderlying(), trainIndex);
     if (numTrains >= maxTrains)
+    {
+        LOG_VERBOSE("Ride %u already at max trains (%u/%u)", id.ToUnderlying(), numTrains, maxTrains);
         return;
+    }
 
     StationIndex stationIndex = RideGetFirstValidStationStart(*this);
     if (stationIndex.IsNull())
+    {
+        LOG_WARNING("Ride %u: no valid station start for replacement train", id.ToUnderlying());
         return;
+    }
 
     TileElement* tileElement = RideGetStationStartTrackElement(*this, stationIndex);
     if (tileElement == nullptr)
+    {
+        LOG_WARNING("Ride %u: missing station track element for replacement train", id.ToUnderlying());
         return;
+    }
 
     TrackElement* trackElement = tileElement->AsTrack();
     CoordsXYZ trainPos = getStation(stationIndex).GetStart();
@@ -5355,7 +5365,10 @@ void Ride::spawnReplacementTrain(uint8_t trainIndex)
     int32_t remainingDistance = 0;
     TrainReference train = VehicleCreateTrain(*this, trainPos, trainIndex, &remainingDistance, trackElement);
     if (train.head == nullptr || train.tail == nullptr)
+    {
+        LOG_WARNING("Ride %u: failed to create replacement train", id.ToUnderlying());
         return;
+    }
 
     if (!vehicles[0].IsNull())
     {
@@ -5382,6 +5395,7 @@ void Ride::spawnReplacementTrain(uint8_t trainIndex)
     vehicles[trainIndex] = train.head->Id;
     numTrains = std::min<uint8_t>(numTrains + 1, maxTrains);
     proposedNumTrains = numTrains;
+    LOG_VERBOSE("Ride %u: spawned replacement train %u", id.ToUnderlying(), trainIndex);
 }
 
 RideClassification Ride::getClassification() const

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -2853,18 +2853,17 @@ void Vehicle::UpdateCollisionSetup()
 
     SetState(Vehicle::Status::Crashed, sub_state);
 
-    std::optional<uint8_t> crashedTrainIndex;
+    auto frontVehicle = GetHead();
+    auto trainIndex = ride_get_train_index_from_vehicle(*curRide, frontVehicle->Id);
+    if (!trainIndex.has_value())
+    {
+        return;
+    }
+
+    std::optional<uint8_t> crashedTrainIndex{ static_cast<uint8_t>(trainIndex.value()) };
 
     if (!(curRide->lifecycleFlags & RIDE_LIFECYCLE_CRASHED))
     {
-        auto frontVehicle = GetHead();
-        auto trainIndex = ride_get_train_index_from_vehicle(*curRide, frontVehicle->Id);
-        if (!trainIndex.has_value())
-        {
-            return;
-        }
-
-        crashedTrainIndex = static_cast<uint8_t>(trainIndex.value());
         curRide->crash(trainIndex.value());
 
         if (!getGameState().cheats.normalizeRideCrashes && curRide->status != RideStatus::closed)
@@ -2933,6 +2932,7 @@ void Vehicle::UpdateCollisionSetup()
 
     if (crashedTrainIndex.has_value() && getGameState().cheats.normalizeRideCrashes)
     {
+        LOG_VERBOSE("Ride %u: spawning replacement train %u after crash", curRide->id.ToUnderlying(), *crashedTrainIndex);
         curRide->spawnReplacementTrain(*crashedTrainIndex);
     }
 }
@@ -4659,18 +4659,17 @@ void Vehicle::CrashOnLand()
     InvokeVehicleCrashHook(Id, "land");
 #endif
 
-    std::optional<uint8_t> crashedTrainIndex;
+    auto frontVehicle = GetHead();
+    auto trainIndex = ride_get_train_index_from_vehicle(*curRide, frontVehicle->Id);
+    if (!trainIndex.has_value())
+    {
+        return;
+    }
+
+    std::optional<uint8_t> crashedTrainIndex{ static_cast<uint8_t>(trainIndex.value()) };
 
     if (!(curRide->lifecycleFlags & RIDE_LIFECYCLE_CRASHED))
     {
-        auto frontVehicle = GetHead();
-        auto trainIndex = ride_get_train_index_from_vehicle(*curRide, frontVehicle->Id);
-        if (!trainIndex.has_value())
-        {
-            return;
-        }
-
-        crashedTrainIndex = static_cast<uint8_t>(trainIndex.value());
         curRide->crash(trainIndex.value());
 
         if (!getGameState().cheats.normalizeRideCrashes && curRide->status != RideStatus::closed)
@@ -4717,6 +4716,7 @@ void Vehicle::CrashOnLand()
 
     if (crashedTrainIndex.has_value() && getGameState().cheats.normalizeRideCrashes)
     {
+        LOG_VERBOSE("Ride %u: spawning replacement train %u after crash", curRide->id.ToUnderlying(), *crashedTrainIndex);
         curRide->spawnReplacementTrain(*crashedTrainIndex);
     }
 }
@@ -4738,18 +4738,17 @@ void Vehicle::CrashOnWater()
     InvokeVehicleCrashHook(Id, "water");
 #endif
 
-    std::optional<uint8_t> crashedTrainIndex;
+    auto frontVehicle = GetHead();
+    auto trainIndex = ride_get_train_index_from_vehicle(*curRide, frontVehicle->Id);
+    if (!trainIndex.has_value())
+    {
+        return;
+    }
+
+    std::optional<uint8_t> crashedTrainIndex{ static_cast<uint8_t>(trainIndex.value()) };
 
     if (!(curRide->lifecycleFlags & RIDE_LIFECYCLE_CRASHED))
     {
-        auto frontVehicle = GetHead();
-        auto trainIndex = ride_get_train_index_from_vehicle(*curRide, frontVehicle->Id);
-        if (!trainIndex.has_value())
-        {
-            return;
-        }
-
-        crashedTrainIndex = static_cast<uint8_t>(trainIndex.value());
         curRide->crash(trainIndex.value());
 
         if (!getGameState().cheats.normalizeRideCrashes && curRide->status != RideStatus::closed)
@@ -4797,6 +4796,7 @@ void Vehicle::CrashOnWater()
 
     if (crashedTrainIndex.has_value() && getGameState().cheats.normalizeRideCrashes)
     {
+        LOG_VERBOSE("Ride %u: spawning replacement train %u after crash", curRide->id.ToUnderlying(), *crashedTrainIndex);
         curRide->spawnReplacementTrain(*crashedTrainIndex);
     }
 }


### PR DESCRIPTION
## Summary
- ensure crashed train index is gathered even if the ride has already crashed
- log when a replacement train is spawned or if prerequisites fail
- add verbose debug logging around replacement train logic

