### PR TITLE
Fix train index overflow by removing crashed trains

### DIFF
--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -5341,7 +5341,7 @@ void Ride::renew()
 
 void Ride::spawnReplacementTrain(uint8_t trainIndex)
 {
-    LOG_INFO("Ride %u: attempt to spawn replacement train %u", id.ToUnderlying(), trainIndex);
+    LOG_INFO("Ride %u: attempt to spawn replacement train for train %u", id.ToUnderlying(), trainIndex);
 
     StationIndex stationIndex = RideGetFirstValidStationStart(*this);
     if (stationIndex.IsNull())
@@ -5362,7 +5362,8 @@ void Ride::spawnReplacementTrain(uint8_t trainIndex)
     trainPos.z = trackElement->GetBaseZ();
 
     int32_t remainingDistance = 0;
-    TrainReference train = VehicleCreateTrain(*this, trainPos, trainIndex, &remainingDistance, trackElement);
+    uint8_t newIndex = trainIndex + 1;
+    TrainReference train = VehicleCreateTrain(*this, trainPos, newIndex, &remainingDistance, trackElement);
     if (train.head == nullptr || train.tail == nullptr)
     {
         LOG_INFO("Ride %u: failed to create replacement train", id.ToUnderlying());
@@ -5391,10 +5392,10 @@ void Ride::spawnReplacementTrain(uint8_t trainIndex)
         train.tail->next_vehicle_on_ride = train.head->Id;
     }
 
-    vehicles[trainIndex] = train.head->Id;
+    vehicles[newIndex] = train.head->Id;
     numTrains = std::min<uint8_t>(numTrains + 1, maxTrains);
     proposedNumTrains = numTrains;
-    LOG_INFO("Ride %u: spawned replacement train %u", id.ToUnderlying(), trainIndex);
+    LOG_INFO("Ride %u: spawned replacement train %u for crashed train %u", id.ToUnderlying(), newIndex, trainIndex);
 }
 
 void Ride::removeTrain(uint8_t trainIndex)

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -5397,6 +5397,24 @@ void Ride::spawnReplacementTrain(uint8_t trainIndex)
     LOG_INFO("Ride %u: spawned replacement train %u", id.ToUnderlying(), trainIndex);
 }
 
+void Ride::removeTrain(uint8_t trainIndex)
+{
+    if (trainIndex >= numTrains)
+        return;
+
+    for (uint8_t i = trainIndex + 1; i < numTrains; ++i)
+    {
+        vehicles[i - 1] = vehicles[i];
+    }
+
+    vehicles[numTrains - 1] = EntityId::GetNull();
+
+    if (numTrains > 0)
+        numTrains--;
+
+    proposedNumTrains = numTrains;
+}
+
 RideClassification Ride::getClassification() const
 {
     const auto& rtd = getRideTypeDescriptor();

--- a/src/openrct2/ride/Ride.h
+++ b/src/openrct2/ride/Ride.h
@@ -360,6 +360,10 @@ public:
      * number of trains.
      */
     void spawnReplacementTrain(uint8_t trainIndex);
+    /**
+     * Remove a train from the ride's vehicle list and update counts.
+     */
+    void removeTrain(uint8_t trainIndex);
 
     bool hasSpinningTunnel() const;
     bool hasWaterSplash() const;

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -2932,6 +2932,7 @@ void Vehicle::UpdateCollisionSetup()
 
     if (crashedTrainIndex.has_value() && getGameState().cheats.normalizeRideCrashes)
     {
+        curRide->removeTrain(*crashedTrainIndex);
         LOG_INFO(
             "Ride %u: spawning replacement train %u after crash; updateCollisionSetup", curRide->id.ToUnderlying(),
             *crashedTrainIndex);
@@ -4718,6 +4719,7 @@ void Vehicle::CrashOnLand()
 
     if (crashedTrainIndex.has_value() && getGameState().cheats.normalizeRideCrashes)
     {
+        curRide->removeTrain(*crashedTrainIndex);
         LOG_INFO(
             "Ride %u: spawning replacement train %u after crash; crashOnLand", curRide->id.ToUnderlying(), *crashedTrainIndex);
         curRide->spawnReplacementTrain(*crashedTrainIndex);
@@ -4799,6 +4801,7 @@ void Vehicle::CrashOnWater()
 
     if (crashedTrainIndex.has_value() && getGameState().cheats.normalizeRideCrashes)
     {
+        curRide->removeTrain(*crashedTrainIndex);
         LOG_INFO(
             "Ride %u: spawning replacement train %u after crash; crashOnWater", curRide->id.ToUnderlying(), *crashedTrainIndex);
         curRide->spawnReplacementTrain(*crashedTrainIndex);

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -2932,12 +2932,9 @@ void Vehicle::UpdateCollisionSetup()
 
     if (crashedTrainIndex.has_value() && getGameState().cheats.normalizeRideCrashes)
     {
+        LOG_INFO("Ride %u: spawning replacement train; updateCollisionSetup", curRide->id.ToUnderlying());
+        curRide->spawnReplacementTrain(*crashedTrainIndex);
         curRide->removeTrain(*crashedTrainIndex);
-        const uint8_t newIndex = curRide->numTrains;
-        LOG_INFO(
-            "Ride %u: spawning replacement train %u after crash; updateCollisionSetup", curRide->id.ToUnderlying(),
-            newIndex);
-        curRide->spawnReplacementTrain(newIndex);
     }
 }
 
@@ -4720,11 +4717,9 @@ void Vehicle::CrashOnLand()
 
     if (crashedTrainIndex.has_value() && getGameState().cheats.normalizeRideCrashes)
     {
+        LOG_INFO("Ride %u: spawning replacement train; crashOnLand", curRide->id.ToUnderlying());
+        curRide->spawnReplacementTrain(*crashedTrainIndex);
         curRide->removeTrain(*crashedTrainIndex);
-        const uint8_t newIndex = curRide->numTrains;
-        LOG_INFO(
-            "Ride %u: spawning replacement train %u after crash; crashOnLand", curRide->id.ToUnderlying(), newIndex);
-        curRide->spawnReplacementTrain(newIndex);
     }
 }
 
@@ -4803,11 +4798,9 @@ void Vehicle::CrashOnWater()
 
     if (crashedTrainIndex.has_value() && getGameState().cheats.normalizeRideCrashes)
     {
+        LOG_INFO("Ride %u: spawning replacement train; crashOnWater", curRide->id.ToUnderlying());
+        curRide->spawnReplacementTrain(*crashedTrainIndex);
         curRide->removeTrain(*crashedTrainIndex);
-        const uint8_t newIndex = curRide->numTrains;
-        LOG_INFO(
-            "Ride %u: spawning replacement train %u after crash; crashOnWater", curRide->id.ToUnderlying(), newIndex);
-        curRide->spawnReplacementTrain(newIndex);
     }
 }
 

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -2933,10 +2933,11 @@ void Vehicle::UpdateCollisionSetup()
     if (crashedTrainIndex.has_value() && getGameState().cheats.normalizeRideCrashes)
     {
         curRide->removeTrain(*crashedTrainIndex);
+        const uint8_t newIndex = curRide->numTrains;
         LOG_INFO(
             "Ride %u: spawning replacement train %u after crash; updateCollisionSetup", curRide->id.ToUnderlying(),
-            *crashedTrainIndex);
-        curRide->spawnReplacementTrain(*crashedTrainIndex);
+            newIndex);
+        curRide->spawnReplacementTrain(newIndex);
     }
 }
 
@@ -4720,9 +4721,10 @@ void Vehicle::CrashOnLand()
     if (crashedTrainIndex.has_value() && getGameState().cheats.normalizeRideCrashes)
     {
         curRide->removeTrain(*crashedTrainIndex);
+        const uint8_t newIndex = curRide->numTrains;
         LOG_INFO(
-            "Ride %u: spawning replacement train %u after crash; crashOnLand", curRide->id.ToUnderlying(), *crashedTrainIndex);
-        curRide->spawnReplacementTrain(*crashedTrainIndex);
+            "Ride %u: spawning replacement train %u after crash; crashOnLand", curRide->id.ToUnderlying(), newIndex);
+        curRide->spawnReplacementTrain(newIndex);
     }
 }
 
@@ -4802,9 +4804,10 @@ void Vehicle::CrashOnWater()
     if (crashedTrainIndex.has_value() && getGameState().cheats.normalizeRideCrashes)
     {
         curRide->removeTrain(*crashedTrainIndex);
+        const uint8_t newIndex = curRide->numTrains;
         LOG_INFO(
-            "Ride %u: spawning replacement train %u after crash; crashOnWater", curRide->id.ToUnderlying(), *crashedTrainIndex);
-        curRide->spawnReplacementTrain(*crashedTrainIndex);
+            "Ride %u: spawning replacement train %u after crash; crashOnWater", curRide->id.ToUnderlying(), newIndex);
+        curRide->spawnReplacementTrain(newIndex);
     }
 }
 


### PR DESCRIPTION
## Summary
- ensure crashed trains are removed from the ride's train list
- update train count when removing trains
- insert replacement trains after cleaning up

## Testing
- `cmake -S . -B build -DWITH_TESTS=ON` *(fails: required package vorbisfile not found)*
- `cmake --build build -j $(nproc)` *(failed: missing nlohmann/json_fwd.hpp)*

------
https://chatgpt.com/codex/tasks/task_e_687319a454ec83328db7312ddc9c9738